### PR TITLE
fix: DM 파이프라인 버그 수정

### DIFF
--- a/airflow/dags/daily_dw_dag.py
+++ b/airflow/dags/daily_dw_dag.py
@@ -68,4 +68,4 @@ with DAG(
         wait_for_completion=True,
     )
 
-    start >> create_schema >> execution_log >> dim_group >> dim_done >> fact_group >> fact_done >> [trigger_keyword_dag, trigger_insight_dag] >> trigger_report_dag >> end
+    start >> create_schema >> execution_log >> dim_group >> dim_done >> fact_group >> fact_done >> [trigger_keyword_dag] >> trigger_report_dag >> end

--- a/spark/spark-jobs/data-mart/create_dm_user_group_comparison.py
+++ b/spark/spark-jobs/data-mart/create_dm_user_group_comparison.py
@@ -1,5 +1,5 @@
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import avg, countDistinct, col, floor, lit
+from pyspark.sql.functions import avg, countDistinct, col, floor, lit, first
 from utils.db import get_mysql_jdbc_url, get_mysql_jdbc_properties
 
 spark = SparkSession.builder.appName("create_dm_user_group_comparison").getOrCreate()
@@ -8,8 +8,9 @@ mysql_url = get_mysql_jdbc_url()
 mysql_props = get_mysql_jdbc_properties()
 
 ratings_df = spark.read.jdbc(mysql_url, "ssabab_dw.fact_user_food_feedback", properties=mysql_props)
-food_df = spark.read.jdbc(mysql_url, "ssabab_dw.dim_menu_food_combined", properties=mysql_props)
+food_df_raw = spark.read.jdbc(mysql_url, "ssabab_dw.dim_menu_food_combined", properties=mysql_props)
 user_df = spark.read.jdbc(mysql_url, "ssabab_dw.dim_user", properties=mysql_props)
+food_df = food_df_raw.groupBy("food_id").agg(first("category_name").alias("category_name"))
 
 joined_df = ratings_df.join(food_df, "food_id").join(user_df, "user_id")
 joined_df = joined_df.withColumn("age_group", floor((2025 - col("birth_year")) / 10))
@@ -22,7 +23,7 @@ user_stats_df = joined_df.groupBy("user_id").agg(
 overall_stats = joined_df.groupBy().agg(
     avg("food_score").alias("group_avg_score"),
     countDistinct("category_name").alias("group_diversity_score")
-).withColumn("group_type", lit("all"))
+).withColumn("group_type", lit("all")).withColumn("group_value", lit("all"))
 
 gender_stats = joined_df.groupBy("gender").agg(
     avg("food_score").alias("group_avg_score"),
@@ -34,26 +35,30 @@ age_stats = joined_df.groupBy("age_group").agg(
     countDistinct("category_name").alias("group_diversity_score")
 ).withColumn("group_type", lit("age")).withColumnRenamed("age_group", "group_value")
 
-user_info = user_df.withColumn("age_group", floor((2025 - col("birth_year")) / 10)).select("user_id", "gender", "age_group")
+user_info = user_df.withColumn("age_group", floor((2025 - col("birth_year")) / 10)) \
+                   .select("user_id", "gender", "age_group")
 
 dm_all = user_stats_df.crossJoin(
-    overall_stats.select("group_type", "group_avg_score", "group_diversity_score")
+    overall_stats.select("group_type", "group_value", "group_avg_score", "group_diversity_score")
 ).select(
-    "user_id", "group_type", "user_avg_score", "group_avg_score", "user_diversity_score", "group_diversity_score"
+    "user_id", "group_type", "group_value", "user_avg_score", "group_avg_score",
+    "user_diversity_score", "group_diversity_score"
 )
 
 dm_gender = user_stats_df.join(user_info, "user_id").join(
     gender_stats,
     (col("gender") == col("group_value")) & (col("group_type") == lit("gender"))
 ).select(
-    "user_id", "group_type", "user_avg_score", "group_avg_score", "user_diversity_score", "group_diversity_score"
+    "user_id", "group_type", "group_value", "user_avg_score", "group_avg_score",
+    "user_diversity_score", "group_diversity_score"
 )
 
 dm_age = user_stats_df.join(user_info, "user_id").join(
     age_stats,
     (col("age_group") == col("group_value")) & (col("group_type") == lit("age"))
 ).select(
-    "user_id", "group_type", "user_avg_score", "group_avg_score", "user_diversity_score", "group_diversity_score"
+    "user_id", "group_type", "group_value", "user_avg_score", "group_avg_score",
+    "user_diversity_score", "group_diversity_score"
 )
 
 dm_user_diversity_df = dm_all.unionByName(dm_gender).unionByName(dm_age)


### PR DESCRIPTION
## 📄 작업 내용

* **리뷰 분석 날짜 오류 수정**: JSON 직렬화 시 `date_format="iso"`를 지정하지 않아 `comment_date`가 1970-01-01로 처리되던 문제 해결
* **중복 음식 처리 개선**: `dim_menu_food_combined` 조인 시 `food_id` 중복으로 인해 평점이 여러 번 계산되던 문제를 `groupBy("user_id", "food_id")`로 평균 처리하여 해결
* **리뷰 단어 추출 시 날짜 포맷 오류 해결**: `comment_date`를 `datetime`으로 명시적 변환 후 문자열 포맷 처리
* **데이터 마트 생성 로직 개선**: `tag_stats`, `category_stats` 등에서 음식 중복으로 인한 집계 오류 방지를 위해 `distinct` 조인 또는 `groupBy("user_id", "food_id")`로 사전 집계 후 처리
* **전반적인 코드 정리** 및 **불필요한 `pandas` 사용 제거**, `Okt` 기반 워드카운트에서 `NaN` 필터링 로직 강화

<br></br>

## 📎 Issue 번호
#4 